### PR TITLE
Order game results web page by date

### DIFF
--- a/Source/NasdaqTraderSystem.Html/HtmlGenerator.cs
+++ b/Source/NasdaqTraderSystem.Html/HtmlGenerator.cs
@@ -97,8 +97,9 @@ public class HtmlGenerator
         context.Games = files.Select(b => new IndexGame()
         {
             GameHTML = Path.Combine(Path.GetFileNameWithoutExtension(b), "GameResult.html"),
-            Name = Path.GetFileNameWithoutExtension(b)
-        }).ToArray();
+            Name = Path.GetFileNameWithoutExtension(b),
+            ExecutionTime = DateTime.ParseExact(Path.GetFileNameWithoutExtension(b), "dd-MM-yyyy-HH-mm", null)
+        }).OrderByDescending(g => g.ExecutionTime).ToArray();
         var indexTemplate = GetTemplate("Index.html");
 
         var template = Handlebars.Compile(indexTemplate);
@@ -152,7 +153,7 @@ public class HtmlGenerator
             {
                 Trade = c.d,
                 Player = c.CompanyName
-            }).OrderBy(c=> c.Trade.ExecutedOn).ToArray();
+            }).OrderBy(c => c.Trade.ExecutedOn).ToArray();
 
         var result = _stockTemplate(context);
         return result;
@@ -246,6 +247,7 @@ internal class IndexGame
 {
     public string GameHTML { get; set; }
     public string Name { get; set; }
+    public DateTime ExecutionTime { get; set; }
 }
 
 internal class IndexContext


### PR DESCRIPTION
# Description
Games zijn niet gesorteerd op datum in de web pagina, deze PR voegt een datum toe en aan de IndexGame class gebaseerd op de filename en sorteert dan hier op. Ik vermoed dat onderstaande lijn waarschijnlijk wel standaard door windows gesorteerd terug kwam maar op m'n linux machine is dit niet :) https://github.com/CSHDJO/NasdaqTradeSystem/blob/ed0c6440a043d53e32289edd507d670499d5d3a9/Source/NasdaqTraderSystem.Html/HtmlGenerator.cs#L76 

# Before
![image](https://github.com/user-attachments/assets/b8b3083a-6d43-44e5-9bab-c49f33bc5d52)


# After
![image](https://github.com/user-attachments/assets/a40be872-cba0-4545-ac2b-3983c0c144f4)
