### PR TITLE
Add --seed parameter to enable deterministic runs

### DIFF
--- a/Source/NasdaqTrader.CLI/Program.cs
+++ b/Source/NasdaqTrader.CLI/Program.cs
@@ -47,12 +47,19 @@ if (!int.TryParse(startingCashAsText, out startingCash))
     startingCash = 1000;
 }
 
+int? seed = null;
+string seedAsText = GetParameter("--seed", "Random generator seed", parameters, shouldPrompt: false);
+if (int.TryParse(seedAsText, out int seedValue))
+{
+	seed = seedValue;
+}
+
 BotLoader botLoader = new BotLoader();
 
 var botTypes = new Dictionary<string, Type>();
 botLoader.DetermineBots(AppContext.BaseDirectory + "Bots", botTypes);
 
-var stocksLoader = new StockLoader(dataFolder, amountOfStock);
+var stocksLoader = new StockLoader(dataFolder, amountOfStock, seed);
 var year = new Random().Next(2021, 2024);
 TraderSystemSimulation traderSystemSimulation = new TraderSystemSimulation(
     botTypes.Values.Select(b => (ITraderBot)Activator.CreateInstance(b)).ToList(),
@@ -99,16 +106,19 @@ if (!runSilent)
     p.Start();
 }
 
-string GetParameter(string parameter, string question, string[] arguments)
+string GetParameter(string parameter, string question, string[] arguments, bool shouldPrompt = true)
 {
     int indexOf = Array.IndexOf(arguments, parameter);
     if (indexOf == -1)
     {
+        if (!shouldPrompt)
+        {
+            return null;
+        }
+
         Console.WriteLine(question);
         return Console.ReadLine();
     }
 
     return arguments[indexOf + 1];
-
-    return "";
 }

--- a/Source/NasdaqTraderSystem.Core/StockLoader.cs
+++ b/Source/NasdaqTraderSystem.Core/StockLoader.cs
@@ -8,9 +8,9 @@ public class StockLoader
     private string[] _selectedCsvs;
     private string _dataFolder;
 
-    public StockLoader(string dataFolder, int amountOfStocks)
+    public StockLoader(string dataFolder, int amountOfStocks, int? seed = null)
     {
-        var random = new Random();
+        Random random = seed == null ? new() : new((int)seed);
         string[] csvFiles = Directory.GetFiles(dataFolder, "*.csv");
 
         _selectedCsvs = new string[amountOfStocks];


### PR DESCRIPTION
Seed word doorgegeven naar StockLoader en hiermee kan je tussen runs elke keer dezelfde stocks laden om te garanderen dat je situatie hetzelfde is en de enigste invloed jou code is.

Ik heb additioneel een boolean flag toegevoegd aan GetParameter dat het niet moet prompten voor deze value om minimale impact te hebben op bestaande code